### PR TITLE
ci: generate GitHub release notes for chart releases

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,7 @@
+# chart-releaser configuration
+# https://github.com/helm/chart-releaser#config-file
+#
+# Populate each chart's GitHub release body with GitHub's auto-generated
+# release notes (merged PRs/commits since the previous tag) instead of the
+# static chart description. This gives Renovate meaningful changelog content.
+generate-release-notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
+        with:
+          config: .github/cr.yaml
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## What

Turns on chart-releaser's `generate-release-notes` via a small `.github/cr.yaml`, wired into the existing action step.

## Why

Right now there's no release-notes source configured, so chart-releaser falls back to the chart `description` for every release. Every release body ends up being the same one-liner, which is exactly what Renovate surfaces when it proposes a chart bump, so the notes are useless where you'd actually read them.

With `generate-release-notes: true`, GitHub builds each release body from the PRs/commits merged since the previous tag. Real changelog, nothing to maintain by hand.

## Changes

- `.github/cr.yaml` sets `generate-release-notes: true`
- `release.yml` passes `config: .github/cr.yaml` to the chart-releaser step

## Notes

Only the release body changes; chart contents, versions, and `index.yaml` are untouched. Notes are only as good as the PR titles behind them, so if you want them grouped by type down the line, a `.github/release.yml` category config handles that.